### PR TITLE
Allow arrays of points to be passed through directly to rasterize_to_tri_strip interface.

### DIFF
--- a/src/c_bindings.rs
+++ b/src/c_bindings.rs
@@ -1,4 +1,4 @@
-use crate::{PathBuilder, OutputVertex, FillMode, rasterize_to_tri_strip};
+use crate::{PathBuilder, OutputPath, OutputVertex, FillMode, rasterize_to_tri_strip};
 use crate::types::{BYTE, POINT};
 
 #[no_mangle]
@@ -38,18 +38,56 @@ pub extern "C" fn wgr_builder_set_fill_mode(pb: &mut PathBuilder, fill_mode: Fil
 }
 
 #[repr(C)]
+pub struct Path {
+    fill_mode: FillMode,
+    points: *const POINT,
+    num_points: usize,
+    types: *const BYTE,
+    num_types: usize,
+}
+
+impl From<OutputPath> for Path {
+    fn from(output_path: OutputPath) -> Self {
+        let path = Self {
+            fill_mode: output_path.fill_mode,
+            points: output_path.points.as_ptr(),
+            num_points: output_path.points.len(),
+            types: output_path.types.as_ptr(),
+            num_types: output_path.types.len(),
+        };
+        std::mem::forget(output_path);
+        path
+    }
+}
+
+impl Into<OutputPath> for Path {
+    fn into(self) -> OutputPath {
+        OutputPath {
+            fill_mode: self.fill_mode,
+            points: unsafe {
+                Box::from_raw(std::slice::from_raw_parts_mut(self.points as *mut POINT, self.num_points))
+            },
+            types: unsafe {
+                Box::from_raw(std::slice::from_raw_parts_mut(self.types as *mut BYTE, self.num_types))
+            },
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn wgr_builder_get_path(pb: &mut PathBuilder) -> Path {
+    Path::from(pb.get_path().unwrap_or_default())
+}
+
+#[repr(C)]
 pub struct VertexBuffer {
     data: *const OutputVertex,
     len: usize
 }
 
 #[no_mangle]
-pub extern "C" fn wgr_rasterize_to_tri_strip(
-    fill_mode: FillMode,
-    types: *const BYTE,
-    num_types: usize,
-    points: *const POINT,
-    num_points: usize,
+pub extern "C" fn wgr_path_rasterize_to_tri_strip(
+    path: &Path,
     clip_x: i32,
     clip_y: i32,
     clip_width: i32,
@@ -57,12 +95,22 @@ pub extern "C" fn wgr_rasterize_to_tri_strip(
     need_inside: bool,
     need_outside: bool,
 ) -> VertexBuffer {
-    let types_slice = unsafe { std::slice::from_raw_parts(types, num_types) };
-    let points_slice = unsafe { std::slice::from_raw_parts(points, num_points) };
-    let result = rasterize_to_tri_strip(fill_mode, types_slice, points_slice, clip_x, clip_y, clip_width, clip_height, need_inside, need_outside);
-    let (data, len) = (result.as_ptr(), result.len());
+    let result = rasterize_to_tri_strip(
+        path.fill_mode,
+        unsafe { std::slice::from_raw_parts(path.types, path.num_types) },
+        unsafe { std::slice::from_raw_parts(path.points, path.num_points) },
+        clip_x, clip_y, clip_width, clip_height,
+        need_inside, need_outside,
+    );
+    let vb = VertexBuffer { data: result.as_ptr(), len: result.len() };
     std::mem::forget(result);
-    VertexBuffer { data, len }
+    vb
+}
+
+#[no_mangle]
+pub extern "C" fn wgr_path_release(path: Path) {
+    let output_path: OutputPath = path.into();
+    drop(output_path);
 }
 
 #[no_mangle]

--- a/src/c_bindings.rs
+++ b/src/c_bindings.rs
@@ -65,10 +65,18 @@ impl Into<OutputPath> for Path {
         OutputPath {
             fill_mode: self.fill_mode,
             points: unsafe {
-                Box::from_raw(std::slice::from_raw_parts_mut(self.points as *mut POINT, self.num_points))
+                if self.points == std::ptr::null() {
+                    Default::default()
+                } else {
+                    Box::from_raw(std::slice::from_raw_parts_mut(self.points as *mut POINT, self.num_points))
+                }
             },
             types: unsafe {
-                Box::from_raw(std::slice::from_raw_parts_mut(self.types as *mut BYTE, self.num_types))
+                if self.types == std::ptr::null() {
+                    Default::default()
+                } else {
+                    Box::from_raw(std::slice::from_raw_parts_mut(self.types as *mut BYTE, self.num_types))
+                }
             },
         }
     }

--- a/src/c_bindings.rs
+++ b/src/c_bindings.rs
@@ -1,4 +1,5 @@
-use crate::{PathBuilder, OutputVertex, FillMode};
+use crate::{PathBuilder, OutputVertex, FillMode, rasterize_to_tri_strip};
+use crate::types::{BYTE, POINT};
 
 #[no_mangle]
 pub extern "C" fn wgr_new_builder() -> *mut PathBuilder {
@@ -43,9 +44,22 @@ pub struct VertexBuffer {
 }
 
 #[no_mangle]
-pub extern "C" fn wgr_rasterize_to_tri_strip(pb: &PathBuilder, clip_x: i32, clip_y: i32, clip_width: i32, clip_height: i32) -> VertexBuffer
-{
-    let result = pb.rasterize_to_tri_strip(clip_x, clip_y, clip_width, clip_height);
+pub extern "C" fn wgr_rasterize_to_tri_strip(
+    fill_mode: FillMode,
+    types: *const BYTE,
+    num_types: usize,
+    points: *const POINT,
+    num_points: usize,
+    clip_x: i32,
+    clip_y: i32,
+    clip_width: i32,
+    clip_height: i32,
+    need_inside: bool,
+    need_outside: bool,
+) -> VertexBuffer {
+    let types_slice = unsafe { std::slice::from_raw_parts(types, num_types) };
+    let points_slice = unsafe { std::slice::from_raw_parts(points, num_points) };
+    let result = rasterize_to_tri_strip(fill_mode, types_slice, points_slice, clip_x, clip_y, clip_width, clip_height, need_inside, need_outside);
     let (data, len) = (result.as_ptr(), result.len());
     std::mem::forget(result);
     VertexBuffer { data, len }

--- a/src/hwrasterizer.rs
+++ b/src/hwrasterizer.rs
@@ -504,7 +504,7 @@ impl CHwRasterizer {
 //-------------------------------------------------------------------------
 pub fn RasterizePath(
     &mut self,
-    rgpt: &[MilPoint2F],
+    rgpt: &[POINT],
     rgTypes: &[BYTE],
     cPoints: UINT,
     pmatWorldTransform: &CMILMatrix
@@ -735,7 +735,7 @@ pub fn Setup(&mut self,
 //-------------------------------------------------------------------------
 pub fn SendGeometry(&mut self,
     pIGeometrySink: Rc<RefCell<CHwVertexBufferBuilder>>,
-    points: &[MilPoint2F],
+    points: &[POINT],
     types: &[BYTE],
     ) -> HRESULT
 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -101,9 +101,9 @@ pub enum MilFillMode {
     Winding = 1,
 }
 
-pub const    PathPointTypeStart: u8           = 0;    // move
-pub const    PathPointTypeLine: u8            = 1;    // line
-pub const    PathPointTypeBezier: u8          = 3;    // default Bezier (= cubic Bezier)
+pub const    PathPointTypeStart: u8           = 0;    // move, 1 point
+pub const    PathPointTypeLine: u8            = 1;    // line, 1 point
+pub const    PathPointTypeBezier: u8          = 3;    // default Bezier (= cubic Bezier), 3 points
 pub const    PathPointTypePathTypeMask: u8    = 0x07; // type mask (lowest 3 bits).
 pub const    PathPointTypeCloseSubpath: u8    = 0x80; // closed flag
 
@@ -199,4 +199,3 @@ pub struct PointXYA
 {
     pub x: f32,pub y: f32, pub a: f32,
 }
- 


### PR DESCRIPTION
Using the PathBuilder interface can be slow when we need to also access the canonical representation of the path for use-cases such as hashing outside wpf-gpu-raster. Also, it allows for faster construction of the point arrays when we can reuse or have specific knowledge of the path.

This does still keep the PathBuilder interface around as a simpler abstraction over the more fundamental rasterize_to_tri_strip function for use-cases where we just need to build the representation once and be done with it.

This also compresses the edge type arrays to only have 1 byte per group of associated points, rather than 1 type per every point, so that we now behave more like Skia where a type corresponds to a "verb" of sorts.