### PR TITLE
Allow PathBuilder to be reset whilst reusing Vec storages

### DIFF
--- a/src/c_bindings.rs
+++ b/src/c_bindings.rs
@@ -8,6 +8,11 @@ pub extern "C" fn wgr_new_builder() -> *mut PathBuilder {
 }
 
 #[no_mangle]
+pub extern "C" fn wgr_builder_reset(pb: &mut PathBuilder) {
+    pb.reset();
+}
+
+#[no_mangle]
 pub extern "C" fn wgr_builder_move_to(pb: &mut PathBuilder, x: f32, y: f32) {
     pb.move_to(x, y);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,15 @@ impl PathBuilder {
             rasterization_truncates: false,
         }
     }
+    fn reset(&mut self) {
+        *self = Self {
+            points: std::mem::take(&mut self.points),
+            types: std::mem::take(&mut self.types),
+            ..Self::new()
+        };
+        self.points.clear();
+        self.types.clear();
+    }
     fn add_point(&mut self, x: f32, y: f32) {
         self.current_point = Some(MilPoint2F{X: x, Y: y});
         // Transform from pixel corner at 0.0 to pixel center at 0.0. Scale into 28.4 range.
@@ -237,8 +246,8 @@ impl PathBuilder {
         if self.valid_range && !self.points.is_empty() && !self.types.is_empty() {
             Some(OutputPath {
                 fill_mode: self.fill_mode,
-                points: std::mem::take(&mut self.points).into_boxed_slice(),
-                types: std::mem::take(&mut self.types).into_boxed_slice(),
+                points: Box::from(self.points.as_slice()),
+                types: Box::from(self.types.as_slice()),
             })
         } else {
             None


### PR DESCRIPTION
Adds a PathBuilder.reset() method along with a C binding that resets a PathBuilder to its default state whilst persisting the storage of the points and types Vecs. The consumer can then reuse a PathBuilder multiple times whilst reducing expensive reallocations.

A consequence of this is that get_path() now copies the contents of the Vecs in to a boxed slice as opposed to consuming the Vecs. In practice, Vec::into_box_slice() usually results in a realloc anyway due to shrinking the Vec's storage to the used size.